### PR TITLE
Fix small bugs for 3 different waveguide width

### DIFF
--- a/klayout_dot_config/tech/EBeam/pymacros/SiEPIC_EBeam-dev Library.lym
+++ b/klayout_dot_config/tech/EBeam/pymacros/SiEPIC_EBeam-dev Library.lym
@@ -7260,7 +7260,7 @@ class ebeam_rib_phase_shifter_folded_inside(pya.PCellDeclarationHelper):
     order = 3; # input/output slab taper curve 
 
     pts = [Point(-l/2,0), Point(l/2, 0)]
-    total_waveguide_length += layout_waveguide2(TECHNOLOGY, self.layout, self.cell, ['Si'], [w*dbu], [0], pts, radius_um, adiab, bezier)
+    total_waveguide_length += layout_waveguide2(TECHNOLOGY, self.layout, self.cell, ['Si'], [folding_w2*dbu], [0], pts, radius_um, adiab, bezier)
 
     
     if self.io_wg_type:
@@ -7272,7 +7272,7 @@ class ebeam_rib_phase_shifter_folded_inside(pya.PCellDeclarationHelper):
       ps_sl_w = contact_size*2 + sw * 2 + (folding_w1 + folding_w2 + folding_gap * 2) * folding_n + edge_slab_width
 
 
-      pts = [Point(-l/2 - in_taper, -w/2), Point( -l/2, -w/2), Point(-l/2, w/2), Point(-l/2 - in_taper, w/2)] # fix waveguide width mismatch for left center input taper
+      pts = [Point(-l/2 - in_taper, -w/2), Point( -l/2, -folding_w2/2), Point(-l/2, folding_w2/2), Point(-l/2 - in_taper, w/2)] # fix waveguide width mismatch for left center input taper
       self.cell.shapes(LayerSiN).insert(Polygon(pts))
   
       # add input slab taper
@@ -7284,7 +7284,7 @@ class ebeam_rib_phase_shifter_folded_inside(pya.PCellDeclarationHelper):
       self.cell.shapes(LayerSlab).insert(Polygon(pts))
   
       # add output strip taper
-      pts = [Point(l/2 + in_taper, -w/2), Point( l/2, -w/2), Point(l/2, w/2), Point(l/2 + in_taper, w/2)]
+      pts = [Point(l/2 + in_taper, -w/2), Point( l/2, -folding_w2/2), Point(l/2, folding_w2/2), Point(l/2 + in_taper, w/2)]
       #wg2 = pya.Box(-l/2,-4/2/dbu,l/2,4/2/dbu)
       self.cell.shapes(LayerSiN).insert(Polygon(pts))
       total_waveguide_length += in_taper*dbu


### PR DESCRIPTION
Hi Lukas,

I fix the bugs so that now we will only have two waveguide width no matter how many fold we have.

Regarding the "middle waveguide doesn't have the overlay_ebl used". I was kind of confusing here. In our previous version, we have slab width start from a little bit narrow that rib part. You may see the screenshot below! I changed it (new version) so that they start from the same width! Let me know which one is more reasonable!

old version:
![old_slab](https://user-images.githubusercontent.com/65426870/82165981-10e90380-9885-11ea-93e5-d78c76c77941.jpg)

changed version:
![changed_slab](https://user-images.githubusercontent.com/65426870/82166020-2827f100-9885-11ea-8447-35a357eff55e.jpg)

