### PR TITLE
Fix waveguide width and slab width bugs

### DIFF
--- a/klayout_dot_config/tech/EBeam/pymacros/SiEPIC_EBeam-dev Library.lym
+++ b/klayout_dot_config/tech/EBeam/pymacros/SiEPIC_EBeam-dev Library.lym
@@ -7260,7 +7260,7 @@ class ebeam_rib_phase_shifter_folded_inside(pya.PCellDeclarationHelper):
     order = 3; # input/output slab taper curve 
 
     pts = [Point(-l/2,0), Point(l/2, 0)]
-    total_waveguide_length += layout_waveguide2(TECHNOLOGY, self.layout, self.cell, ['Si'], [w*dbu], [0], pts, radius_um, adiab, bezier)
+    total_waveguide_length += layout_waveguide2(TECHNOLOGY, self.layout, self.cell, ['Si'], [folding_w2*dbu], [0], pts, radius_um, adiab, bezier)
 
     
     if self.io_wg_type:
@@ -7272,19 +7272,19 @@ class ebeam_rib_phase_shifter_folded_inside(pya.PCellDeclarationHelper):
       ps_sl_w = contact_size*2 + sw * 2 + (folding_w1 + folding_w2 + folding_gap * 2) * folding_n + edge_slab_width
 
 
-      pts = [Point(-l/2 - in_taper, -w/2), Point( -l/2, -w/2), Point(-l/2, w/2), Point(-l/2 - in_taper, w/2)] # fix waveguide width mismatch for left center input taper
+      pts = [Point(-l/2 - in_taper, -w/2), Point( -l/2, -folding_w2/2), Point(-l/2, folding_w2/2), Point(-l/2 - in_taper, w/2)] # fix waveguide width mismatch for left center input taper
       self.cell.shapes(LayerSiN).insert(Polygon(pts))
   
       # add input slab taper
       pts = [];
       for i in range(0,N + 1):
-        pts.append(Point(-l/2 - in_taper + in_taper/N * i, w/2 + ((2/dbu - (w-overlay_ebl))/(N**order))*(i**order)))
+        pts.append(Point(-l/2 - in_taper + in_taper/N * i, (w-overlay_ebl)/2 + ((2/dbu - (w-overlay_ebl))/(N**order))*(i**order)))
       for i in range(0,N + 1):
-        pts.append(Point(-l/2 - in_taper + in_taper/N * (N - i), - w/2 - ((2/dbu - (w-overlay_ebl))/(N**order))*((N-i)**order)))
+        pts.append(Point(-l/2 - in_taper + in_taper/N * (N - i), - (w-overlay_ebl)/2 - ((2/dbu - (w-overlay_ebl))/(N**order))*((N-i)**order)))
       self.cell.shapes(LayerSlab).insert(Polygon(pts))
   
       # add output strip taper
-      pts = [Point(l/2 + in_taper, -w/2), Point( l/2, -w/2), Point(l/2, w/2), Point(l/2 + in_taper, w/2)]
+      pts = [Point(l/2 + in_taper, -w/2), Point( l/2, -folding_w2/2), Point(l/2, folding_w2/2), Point(l/2 + in_taper, w/2)]
       #wg2 = pya.Box(-l/2,-4/2/dbu,l/2,4/2/dbu)
       self.cell.shapes(LayerSiN).insert(Polygon(pts))
       total_waveguide_length += in_taper*dbu
@@ -7292,9 +7292,9 @@ class ebeam_rib_phase_shifter_folded_inside(pya.PCellDeclarationHelper):
       # add input slab taper
       pts = [];
       for i in range(0,N + 1):
-        pts.append(Point(l/2 + in_taper - in_taper/N * i, (w)/2 + ((2/dbu - (w-overlay_ebl))/(N**order))*(i**order)))
+        pts.append(Point(l/2 + in_taper - in_taper/N * i, (w-overlay_ebl)/2 + ((2/dbu - (w-overlay_ebl))/(N**order))*(i**order)))
       for i in range(0,N + 1):
-        pts.append(Point(l/2 + in_taper/N * i, - (w)/2 - ((2/dbu - (w-overlay_ebl))/(N**order))*((N-i)**order)))
+        pts.append(Point(l/2 + in_taper/N * i, - (w-overlay_ebl)/2 - ((2/dbu - (w-overlay_ebl))/(N**order))*((N-i)**order)))
       self.cell.shapes(LayerSlab).insert(Polygon(pts))
 
       for i in range(0, folding_n):
@@ -7322,9 +7322,9 @@ class ebeam_rib_phase_shifter_folded_inside(pya.PCellDeclarationHelper):
         # slab cubic taper
         pts = [];
         for ii in range(0,N + 1):
-          pts.append(Point(-l/2 - in_taper + in_taper/N * ii, (w)/2 + ((2/dbu - (w-overlay_ebl))/(N**order))*(ii**order)+y_move))
+          pts.append(Point(-l/2 - in_taper + in_taper/N * ii, (w-overlay_ebl)/2 + ((2/dbu - (w-overlay_ebl))/(N**order))*(ii**order)+y_move))
         for ii in range(0,N + 1):
-          pts.append(Point(-l/2 - in_taper + in_taper/N * (N - ii), - (w)/2 - ((2/dbu - (w-overlay_ebl))/(N**order))*((N-ii)**order)+y_move))
+          pts.append(Point(-l/2 - in_taper + in_taper/N * (N - ii), - (w-overlay_ebl)/2 - ((2/dbu - (w-overlay_ebl))/(N**order))*((N-ii)**order)+y_move))
         self.cell.shapes(LayerSlab).insert(Polygon(pts))      
         
                 
@@ -7339,10 +7339,10 @@ class ebeam_rib_phase_shifter_folded_inside(pya.PCellDeclarationHelper):
           # slab cubic taper
           pts = [];
           for ii in range(0,N + 1):
-            pts.append(Point(-l/2 - in_taper + in_taper/N * ii, (w)/2 + ((2/dbu - (w-overlay_ebl))/(N**order))*(ii**order)+
+            pts.append(Point(-l/2 - in_taper + in_taper/N * ii, (w-overlay_ebl)/2 + ((2/dbu - (w-overlay_ebl))/(N**order))*(ii**order)+
             y_move))
           for ii in range(0,N + 1):
-            pts.append(Point(-l/2 - in_taper + in_taper/N * (N - ii), - (w)/2 - ((2/dbu - (w-overlay_ebl))/(N**order))*((N-ii)**order)+
+            pts.append(Point(-l/2 - in_taper + in_taper/N * (N - ii), - (w-overlay_ebl)/2 - ((2/dbu - (w-overlay_ebl))/(N**order))*((N-ii)**order)+
             y_move))
           self.cell.shapes(LayerSlab).insert(Polygon(pts))     
         
@@ -7356,9 +7356,9 @@ class ebeam_rib_phase_shifter_folded_inside(pya.PCellDeclarationHelper):
           # slab cubic taper
           pts = [];
           for ii in range(0,N + 1):
-            pts.append(Point(l/2 + in_taper - in_taper/N * ii, (w)/2 + ((2/dbu - (w-overlay_ebl))/(N**order))*(ii**order) + y_move))
+            pts.append(Point(l/2 + in_taper - in_taper/N * ii, (w-overlay_ebl)/2 + ((2/dbu - (w-overlay_ebl))/(N**order))*(ii**order) + y_move))
           for ii in range(0,N + 1):
-            pts.append(Point(l/2 + in_taper/N * ii, - (w)/2 - ((2/dbu - (w-overlay_ebl))/(N**order))*((N-ii)**order) + y_move))
+            pts.append(Point(l/2 + in_taper/N * ii, - (w-overlay_ebl)/2 - ((2/dbu - (w-overlay_ebl))/(N**order))*((N-ii)**order) + y_move))
           self.cell.shapes(LayerSlab).insert(Polygon(pts)) 
 
         else:


### PR DESCRIPTION
Hi Lukas,

Thanks for your feedback and help! I update the code to fix two bugs. Let me know if more bugs still exist.
1. Now the Pcell will use only two waveguide width no matter how many folds we have.
2. The overlay_ebl for slab waveguide is used for all input taper!