### PR TITLE
Schedule docker rebuild to run daily + remove unneeded docker build trigger

### DIFF
--- a/.github/workflows/Docker_Image.yml
+++ b/.github/workflows/Docker_Image.yml
@@ -1,6 +1,8 @@
 name: Create and Publish Docker Image
 
 on:
+  schedule:
+    - cron: '0 0 * * *'
   workflow_dispatch:
   release:
     types:

--- a/.github/workflows/EBeam_Tests.yml
+++ b/.github/workflows/EBeam_Tests.yml
@@ -72,12 +72,6 @@ jobs:
         run: docker exec ebeam_test klayout -zz -r pymacros/EBeam_Lib_PCellTests.py || echo "KLAYOUT_EXIT_CODE=$?" >> $GITHUB_ENV
         continue-on-error: true
 
-      - name: Trigger Docker build workflow if new pcells were added on a push or a merged PR #since merged commmits act as a direct push
-        if: github.event_name == 'push' && steps.added-files.outputs.added_files != ''
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh workflow run Docker_Image.yml
-
       - name: Stop container and remove it 
         run: |
                 docker stop ebeam_test


### PR DESCRIPTION
- adding in a line to run the docker build action every day at midnight
- don't need to trigger the docker build action if a new pcell is added because ebeam action is modified now to copy all of the content of the repo into klayout's version of siepic ebeam pdk in the docker container. This ensures that the tests are referencing the most up to date repo files.